### PR TITLE
Added declare due error Typescript

### DIFF
--- a/src/components/Image/Image.d.ts
+++ b/src/components/Image/Image.d.ts
@@ -12,5 +12,5 @@ export interface ImageProps {
     onClick?: (event:React.MouseEvent<HTMLElement> ) => any,
     style?: object
 }
-const ImageComponent: React.ComponentType<ImageProps>;
+declare const ImageComponent: React.ComponentType<ImageProps>;
 export default ImageComponent;


### PR DESCRIPTION
I just added this keyword because typescripts return an error on this definition. :+1: 
`A 'declare' modifier is required for a top level declaration in a .d.ts file.`

https://stackoverflow.com/questions/17635033/error-ts1046-declare-modifier-required-for-top-level-element