### PR TITLE
fix: remove error state on successful load

### DIFF
--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -98,7 +98,7 @@ export default class Image extends Component {
   }
 
   handleLoadImage = (e) => {
-    this.setState({ imageLoaded: true })
+    this.setState({ imageLoaded: true, imageError: false })
     if (this.props.onLoad) {
       this.props.onLoad(e)
     }


### PR DESCRIPTION
In Firefox a SVG loaded from cache shows the error icon after load.
Looks like this happens because `naturalWidth` of an SVG is 0 when it's loaded from cache in FF. At least that's whats happening here.

- It loads fine initially
- component with the image gets removed
- same component is added again, `componentDidMount` throws the load error because `naturalWidth === 0`

There are ancient bugs in Firefox describing the issue, so there is not much one can do I think. 

The `handleLoadImage` callback fires after the error though, so it should be enough to set the `imageError` state to `false` to fix the issue. Right now I see the image and the error icon at the same time when that happens
