### PR TITLE
Fix for console error on iconContainerStyle

### DIFF
--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -126,10 +126,11 @@ export default class Image extends Component {
       disableSpinner,
       disableTransition,
       errorIcon,
+      iconContainerStyle,
       imageStyle,
-      style,
       loading,
       onClick,
+      style,
       ...image
     } = this.props
 


### PR DESCRIPTION
Html img component does not have a property "iconContainerStyle", so this should be removed.

Error in console:
```
 console.error node_modules/@testing-library/react/dist/act-compat.js:52

      Warning: React does not recognize the `iconContainerStyle` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `iconcontainerstyle` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Closes #62.