### PR TITLE
Fix non-boolean attribute `cover` error

### DIFF
--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -122,6 +122,7 @@ export default class Image extends Component {
       animationDuration,
       aspectRatio,
       color,
+      cover,
       disableError,
       disableSpinner,
       disableTransition,


### PR DESCRIPTION
When using the prop _cover_, the browser throws the following warning in the console:

```
index.js:1 Warning: Received `false` for a non-boolean attribute `cover`.

If you want to write it to the DOM, pass a string instead: cover="false" or cover={value.toString()}.

If you used to conditionally omit it with cover={condition && value}, pass cover={condition ? value : undefined} instead.
```

This PR resolves this warning.